### PR TITLE
【bug修复】Redis使用GenericJackson2JsonRedisSerializer序列化时，无法序列化LocalDateTime类型

### DIFF
--- a/blog-framework/pom.xml
+++ b/blog-framework/pom.xml
@@ -77,6 +77,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+
+        <!-- redis默认的JSON序列化器无法处理LocalDateTime类型的对象 -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/blog-framework/src/main/java/com/hunter/config/RedisConfig.java
+++ b/blog-framework/src/main/java/com/hunter/config/RedisConfig.java
@@ -1,9 +1,12 @@
 package com.hunter.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 
 /**
@@ -23,10 +26,16 @@ public class RedisConfig {
         // 使用StringRedisSerializer.UTF_8作为key和hash key的序列化器
         template.setKeySerializer(RedisSerializer.string());
         template.setHashKeySerializer(RedisSerializer.string());
+
         // 使用GenericJackson2JsonRedisSerializer作为value和hash value的序列化器。
         // 被序列化的对象，getter方法也会被读取形成property，成为被序列化的一部分
-        template.setValueSerializer(RedisSerializer.json());
-        template.setHashValueSerializer(RedisSerializer.json());
+        ObjectMapper objectMapper = new ObjectMapper();
+        // 注册JavaTimeModule，支持LocalDateTime等时间类型
+        objectMapper.registerModule(new JavaTimeModule());
+        GenericJackson2JsonRedisSerializer jackson2JsonRedisSerializer =
+                new GenericJackson2JsonRedisSerializer(objectMapper);
+        template.setValueSerializer(jackson2JsonRedisSerializer);
+        template.setHashValueSerializer(jackson2JsonRedisSerializer);
 
         // 对配置进行初始化
         template.afterPropertiesSet();

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <jwt>4.4.0</jwt>
         <qiniu>7.17.0</qiniu>
         <gson>2.11.0</gson>
+        <jackson>2.18.1</jackson>
     </properties>
 
     <!-- 依赖版本控制 -->
@@ -80,6 +81,12 @@
                 <version>${gson}</version>
             </dependency>
 
+            <!-- redis默认的JSON序列化器无法处理LocalDateTime类型的对象 -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
序列化器需要注册JavaTimeModule，以支持LocalDateTime类型